### PR TITLE
Change to run `npm start` command in Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@ Starter kit for theme of Redmine.
 2. Access to http://localhost:8080/ on web browser
 3. Sign in to Redmine as an administrator
 4. Select `mytheme` as the theme from the administration screen.
-5. Make changes to assets/*
+5. Make changes to `assets/*`
 6. Reload the web browser and check the screen
 
-If you make a change to src/assets/scss/*, it will be automatically compile SCSS.
+If you make a change to `src/assets/scss/*`, it will be automatically compile SCSS.
 
 Stop is `docker-compose stop`.
+
+## Release
+
+1. `docker-compose exec nodejs npm run release`
+2. Release the created mytheme, mytheme.zip
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,31 +2,21 @@
 
 Starter kit for theme of Redmine.
 
+## Install
+
+1. Install [Docker](https://www.docker.com/) and [Docker-Compose](https://docs.docker.com/compose/).
+2. `git clone https://github.com/akabekobeko/redmine-theme-starter.git`
+
 ## Development
-
-### Setup
-
-1. Install [Node.js](https://nodejs.org/en/).js (bundled [npm](https://www.npmjs.com/))
-2. Install [Docker](https://www.docker.com/) and [Docker-Compose](https://docs.docker.com/compose/).
-3. `git clone https://github.com/akabekobeko/redmine-theme-starter.git`
-4. `cd redmine-theme-starter`
-5. `npm i`
-
-### Watch build for CSS
-
-Transpile (watch) CSS with watch mode.
-
-- Preview: `npm start`
-- Stop: <kbd>Ctrl</kbd> + <kbd>C</kbd>
-
-### Preview on Redmine
-
-Start Redmine and check it.
 
 1. `docker-compose up -d`
 2. Access to http://localhost:8080/ on web browser
 3. Sign in to Redmine as an administrator
 4. Select `mytheme` as the theme from the administration screen.
+5. Make changes to assets/*
+6. Reload the web browser and check the screen
+
+If you make a change to src/assets/scss/*, it will be automatically compile SCSS.
 
 Stop is `docker-compose stop`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,10 @@ services:
       MYSQL_USER: redmine_mytheme
       MYSQL_PASSWORD: redmine_mytheme
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+
+  nodejs:
+      image: node:13
+      volumes:
+          - ./:/app
+      working_dir: /app
+      command: bash -c "npm install && npm start"


### PR DESCRIPTION
ローカルで`npm i`や`npm start`を実行したりしなくても良くなるように、それらも`docker-compose up`をしたら自動で実行されるようにしました。  
テーマを作る上での開発の詰まりポイントをより減らせるのではないかと思います。

(ローカルで実行した方がSCSS を CSS に変換する様子が分かりやすいですし、docker化がすべてにおいて良いという訳ではないです。)